### PR TITLE
recovery: fix has_metadata check for A/B

### DIFF
--- a/install/install.cpp
+++ b/install/install.cpp
@@ -350,7 +350,7 @@ static InstallResult TryUpdateBinary(Package* package, bool* wipe_cache,
   auto zip = package->GetZipArchiveHandle();
   bool has_metadata = ReadMetadataFromPackage(zip, &metadata);
 
-  bool package_is_ab = !has_metadata && get_value(metadata, "ota-type") == OtaTypeToString(OtaType::AB);
+  bool package_is_ab = has_metadata && get_value(metadata, "ota-type") == OtaTypeToString(OtaType::AB);
   bool device_supports_ab = android::base::GetBoolProperty("ro.build.ab_update", false);
   bool ab_device_supports_nonab = true;
   bool device_only_supports_ab = device_supports_ab && !ab_device_supports_nonab;


### PR DESCRIPTION
LineageOS inadvertently fixed this with an irrelevant commit: https://github.com/LineageOS/android_bootable_recovery/commit/f09adaae79844a7eaa48396d5ebaa577ec5b6819

Change-Id: I1c00c1494546fa34e4597cf81eadae7a427871a4